### PR TITLE
Fix GPIOTE interrupt priority

### DIFF
--- a/cores/nRF5/WInterrupts.c
+++ b/cores/nRF5/WInterrupts.c
@@ -42,7 +42,7 @@ static void __initialize()
 
   NVIC_DisableIRQ(GPIOTE_IRQn);
   NVIC_ClearPendingIRQ(GPIOTE_IRQn);
-  NVIC_SetPriority(GPIOTE_IRQn, 1);
+  NVIC_SetPriority(GPIOTE_IRQn, 2);
   NVIC_EnableIRQ(GPIOTE_IRQn);
 }
 


### PR DESCRIPTION
The GPIOTE interrupt priority is higher than allowed by FREERTOS